### PR TITLE
Wrong SQL generation

### DIFF
--- a/lib/big_sitemap.rb
+++ b/lib/big_sitemap.rb
@@ -134,7 +134,7 @@ class BigSitemap
         end
         
         # Keep the initial conditions for later use
-        conditions = find_options[:conditions].clone
+        conditions = find_options[:conditions]
 
         primary_column   = options.delete(:primary_column)
 


### PR DESCRIPTION
Hi,

i just fixed wrong sql condition handling which resulted in a very long concatenation of id > 1001 AND id > 2001 and so on

snippet from my log file:
SELECT osm_id, status, updated_at FROM `pois` WHERE ((osm_id > 11325136) AND (osm_id > 15955360) AND (osm_id > 18672676) AND (osm_id > 20973488) AND (osm_id > 21436919) AND (osm_id > 23660941)) LIMIT 1001

Hope this commit finds it way to into your repository.

Cheers, Christoph
