### PR TITLE
Don't fail when an engine can't be contacted.

### DIFF
--- a/lib/massive_sitemap/ping.rb
+++ b/lib/massive_sitemap/ping.rb
@@ -16,7 +16,10 @@ module MassiveSitemap
 
     Array(engines).each do |engine|
       if engine_url = ENGINES_URLS[engine]
-        open(engine_url % url)
+        begin
+          open(engine_url % url)
+        rescue SocketError
+        end
       end
     end
   end

--- a/spec/ping_spec.rb
+++ b/spec/ping_spec.rb
@@ -27,6 +27,12 @@ describe MassiveSitemap do
           MassiveSitemap.ping(url, :unknown)
         end.to_not raise_error
       end
+
+      it "doesn't fail when it can't talk to an engine" do
+        MassiveSitemap.should_receive(:open).twice.and_raise(SocketError)
+
+        MassiveSitemap.ping(url, [:google, :ask])
+      end
     end
   end
 end


### PR DESCRIPTION
We've been getting a lot of errors in Airbrake lately about MassiveSitemap failing. It looks like they were caused by ask.com's sitemap submission service being down, since I can't access that url. To workaround this, I've simply wrapped the calls that ping the external URL to ignore the SocketError when a server can't be reached. :cake:
