### PR TITLE
Fixes UTF-8 conversion error with GZIP filewriter #5

### DIFF
--- a/lib/massive_sitemap/writer/file.rb
+++ b/lib/massive_sitemap/writer/file.rb
@@ -30,7 +30,7 @@ module MassiveSitemap
         ::File.dirname(tmp_filename).tap do |dir|
           FileUtils.mkdir_p(dir) unless ::File.exists?(dir)
         end
-        ::File.open(tmp_filename, 'w')
+        ::File.open(tmp_filename, 'wb')
       end
 
       def close_stream(file)


### PR DESCRIPTION
This fixes "\x8B" from ASCII-8BIT to UTF-8 message when using gzip/s3 writer. ( #5 )
